### PR TITLE
Fix bugs in the class finder

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+coverage_clover: clover.xml
+json_path: coveralls-upload.json

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,22 +15,21 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
-          extensions: mbstring, intl, xdebug, sqlite3
+          extensions: mbstring, intl, xdebug, sqlite3, xml, simplexml
           tools: composer:v2
           coverage: xdebug
 
-      - name: PHP Version
-        run: php -v
+      - name: Composer Check
+        run: composer validate
 
-      - name: Install dependencies
-        if: steps.composer-cache.outputs.cache-hit != 'true'
+      - name: Install
         run: |
-          composer self-update
-          composer validate
-          composer install --prefer-dist --no-progress
+          composer install --prefer-dist --no-interaction --no-progress
+          composer update
 
       - name: Static Analysis
         run: composer analyze
+
       - name: Coverage Report
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,6 +16,8 @@ jobs:
         with:
           php-version: '8.1'
           extensions: mbstring, intl, xdebug, sqlite3
+          tools: composer:v2
+          coverage: xdebug
 
       - name: PHP Version
         run: php -v

--- a/src/Utility/NamespaceUtility.php
+++ b/src/Utility/NamespaceUtility.php
@@ -15,7 +15,7 @@ class NamespaceUtility
      * Finds classes using the $namespace argument and returns an array of namespaces as strings.
      *
      * @param string|null $namespace A namespace such as `App\Controller`, if null, the `App.namespace` config is used.
-     * @param string[] $paths A list of absolute paths to load classes from
+     * @param array<string> $paths A list of absolute paths to load classes from
      * @return array<string>
      */
     public static function findClasses(?string $namespace = null, array $paths = []): array

--- a/src/Utility/NamespaceUtility.php
+++ b/src/Utility/NamespaceUtility.php
@@ -5,24 +5,20 @@ namespace MixerApi\Core\Utility;
 
 use Cake\Collection\Collection;
 use Cake\Core\Configure;
+use Cake\Core\Plugin;
 use Kcs\ClassFinder\Finder\ComposerFinder;
 use RuntimeException;
 
-/**
- * Namespace Utilities
- *
- * @uses \Mouf\Composer\ClassNameMapper
- * @uses \TheCodingMachine\ClassExplorer\Glob\GlobClassExplorer
- */
 class NamespaceUtility
 {
     /**
      * Finds classes using the $namespace argument and returns an array of namespaces as strings.
      *
      * @param string|null $namespace A namespace such as `App\Controller`, if null, the `App.namespace` config is used.
+     * @param string[] $paths A list of absolute paths to load classes from
      * @return array<string>
      */
-    public static function findClasses(?string $namespace = null): array
+    public static function findClasses(?string $namespace = null, array $paths = []): array
     {
         $namespace = $namespace ?? Configure::read('App.namespace');
         if (str_starts_with($namespace, '\\')) {
@@ -31,7 +27,22 @@ class NamespaceUtility
         if (str_ends_with($namespace, '\\')) {
             $namespace = substr($namespace, 0, strlen($namespace) - 1);
         }
-        $finder = (new ComposerFinder())->inNamespace($namespace);
+
+        if (empty($paths)) {
+            $paths = [APP];
+
+            /** @var \Cake\Core\BasePlugin $plugin */
+            foreach (Plugin::getCollection() as $plugin) {
+                if (str_contains('/vendor/', $plugin->getClassPath())) {
+                    continue;
+                }
+                $paths[] = $plugin->getClassPath();
+            }
+        }
+
+        $finder = (new ComposerFinder())
+            ->inNamespace($namespace)
+            ->in($paths);
         $classes = [];
         foreach ($finder as $className => $reflector) {
             $classes[] = $className;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,6 +28,22 @@ use Cake\TestSuite\Fixture\SchemaLoader;
  */
 require dirname(__DIR__) . '/vendor/autoload.php';
 
+// Path constants to a few helpful things.
+if (!defined('DS')) {
+    define('DS', DIRECTORY_SEPARATOR);
+}
+define('ROOT', dirname(__DIR__));
+define('CAKE_CORE_INCLUDE_PATH', ROOT . DS . 'vendor' . DS . 'cakephp' . DS . 'cakephp');
+define('CORE_PATH', ROOT . DS . 'vendor' . DS . 'cakephp' . DS . 'cakephp' . DS);
+define('CAKE', CORE_PATH . 'src' . DS);
+define('TESTS', ROOT . DS . 'tests');
+define('APP', ROOT . DS . 'tests' . DS . 'test_app' . DS);
+define('APP_DIR', 'test_app');
+define('WEBROOT_DIR', 'webroot');
+define('WWW_ROOT', APP . 'webroot' . DS);
+
+require_once CORE_PATH . 'config/bootstrap.php';
+
 $_SERVER['PHP_SELF'] = '/';
 
 define('IS_TEST', true);


### PR DESCRIPTION
NamespaceUtility is loading in classes from test paths and generally loading non-PSR classes. This PR limits class loading to src paths in the userland application.