### PR TITLE
Fix CakePHP 5.3 compatibility in ModelPropertyFactory

### DIFF
--- a/src/Model/ModelPropertyFactory.php
+++ b/src/Model/ModelPropertyFactory.php
@@ -34,34 +34,27 @@ class ModelPropertyFactory
      */
     public function create(): ModelProperty
     {
-        $vars = $this->schema->__debugInfo();
-        $default = $vars['columns'][$this->columnName]['default'] ?? '';
+        $column = $this->schema->getColumn($this->columnName);
+        $default = $column['default'] ?? '';
 
         return (new ModelProperty())
             ->setName($this->columnName)
             ->setType($this->schema->getColumnType($this->columnName))
             ->setDefault((string)$default)
-            ->setIsPrimaryKey($this->isPrimaryKey($vars, $this->columnName))
+            ->setIsPrimaryKey($this->isPrimaryKey())
             ->setIsHidden(in_array($this->columnName, $this->entity->getHidden()))
             ->setIsAccessible($this->isAccessible())
             ->setValidationSet($this->table->validationDefault(new Validator())->field($this->columnName));
     }
 
     /**
-     * @param array $schemaDebugInfo debug array from TableSchema
-     * @param string $columnName column name
+     * Checks if this column is part of the primary key.
+     *
      * @return bool
      */
-    private function isPrimaryKey(array $schemaDebugInfo, string $columnName): bool
+    private function isPrimaryKey(): bool
     {
-        // ignore coverage since this condition should not be met
-        if (!isset($schemaDebugInfo['constraints']['primary']['columns'])) {
-            // @codeCoverageIgnoreStart
-            return false;
-            // @codeCoverageIgnoreEnd
-        }
-
-        return in_array($columnName, $schemaDebugInfo['constraints']['primary']['columns']);
+        return in_array($this->columnName, $this->schema->getPrimaryKey());
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes CakePHP 5.3 compatibility issue where `ModelPropertyFactory` breaks because `__debugInfo()` now returns `Column` objects instead of arrays.

## Changes

- Replace `__debugInfo()` with `getColumn()` for column default value
- Simplify `isPrimaryKey()` to use `getPrimaryKey()` public API

Both methods are stable public API that return arrays for backwards compatibility.

Fixes mixerapi/mixerapi-dev#159